### PR TITLE
use bash for if fi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Installation
 
-Run ```curl -sS https://raw.githubusercontent.com/ksangers/uamp-dev-environment/master/install-env-dev.sh | sh -s -- [options]``` to install.
+Run ```curl -sS https://raw.githubusercontent.com/ksangers/uamp-dev-environment/master/install-env-dev.sh | bash -s -- [options]``` to install.
 
 Options:
 ```


### PR DESCRIPTION
Executing script with sh instead of bash leads to syntax error near mailcatcher install 